### PR TITLE
Wither abilities, fixes #224

### DIFF
--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/PandemoniumRequiemPlugin.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/PandemoniumRequiemPlugin.java
@@ -49,6 +49,7 @@ import ladysnake.requiem.api.v1.remnant.RemnantComponent;
 import ladysnake.requiem.common.entity.ability.RangedAttackAbility;
 import ladysnake.requiem.common.network.RequiemNetworking;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.mob.EvokerEntity;
 import net.minecraft.entity.mob.GuardianEntity;
@@ -118,5 +119,6 @@ public class PandemoniumRequiemPlugin implements RequiemPlugin {
         abilityRegistry.register(EntityType.LLAMA, MobAbilityConfig.<LlamaEntity>builder().directAttack(RangedAttackAbility::new).build());
         abilityRegistry.register(EntityType.TRADER_LLAMA, MobAbilityConfig.<LlamaEntity>builder().directAttack(RangedAttackAbility::new).build());
         abilityRegistry.register(EntityType.WITCH, MobAbilityConfig.<WitchEntity>builder().directAttack(owner -> new RangedAttackAbility<>(owner, 50, 10.)).build());
+        abilityRegistry.register(EntityType.WITHER, MobAbilityConfig.<WitherEntity>builder().indirectAttack(WitherSkullAbility.BlueWitherSkullAbility::new).directAttack(WitherSkullAbility.BlackWitherSkullAbility::new).build());
     }
 }

--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/common/entity/ability/WitherSkullAbility.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/common/entity/ability/WitherSkullAbility.java
@@ -1,3 +1,37 @@
+/*
+ * Requiem
+ * Copyright (C) 2017-2021 Ladysnake
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses>.
+ *
+ * Linking this mod statically or dynamically with other
+ * modules is making a combined work based on this mod.
+ * Thus, the terms and conditions of the GNU General Public License cover the whole combination.
+ *
+ * In addition, as a special exception, the copyright holders of
+ * this mod give you permission to combine this mod
+ * with free software programs or libraries that are released under the GNU LGPL
+ * and with code included in the standard release of Minecraft under All Rights Reserved (or
+ * modified versions of such code, with unchanged license).
+ * You may copy and distribute such a system following the terms of the GNU GPL for this mod
+ * and the licenses of the other code concerned.
+ *
+ * Note that people who make modified versions of this mod are not obligated to grant
+ * this special exception for their modified versions; it is their choice whether to do so.
+ * The GNU General Public License gives permission to release a modified version without this exception;
+ * this exception also makes it possible to release a modified version which carries forward this exception.
+ */
 package ladysnake.pandemonium.common.entity.ability;
 
 import ladysnake.requiem.api.v1.entity.ability.DirectAbility;

--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/common/entity/ability/WitherSkullAbility.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/common/entity/ability/WitherSkullAbility.java
@@ -1,0 +1,133 @@
+package ladysnake.pandemonium.common.entity.ability;
+
+import ladysnake.requiem.common.entity.ability.DirectAbilityBase;
+import ladysnake.requiem.common.entity.ability.IndirectAbilityBase;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.boss.WitherEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.WitherSkullEntity;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.Random;
+
+public class WitherSkullAbility {
+    public static class BlueWitherSkullAbility extends IndirectAbilityBase<WitherEntity> {
+        private static final Random RANDOM = new Random();
+
+        public BlueWitherSkullAbility(WitherEntity owner, int cooldown) {
+            super(owner, cooldown);
+        }
+
+        public BlueWitherSkullAbility(WitherEntity owner) {
+            this(owner,40);
+        }
+
+        @Override
+        protected boolean run() {
+            if (!owner.isSilent()) {
+                owner.world.syncWorldEvent(null, 1024, owner.getBlockPos(), 0);
+            }
+            Vec3d rot = this.owner.getRotationVec(1.0f).multiply(10);
+            WitherSkullEntity witherSkullEntity = new WitherSkullEntity(
+                this.owner.world,
+                this.owner,
+                rot.x + this.owner.getRandom().nextGaussian(),
+                rot.y,
+                rot.z + this.owner.getRandom().nextGaussian()
+            );
+            witherSkullEntity.setOwner(owner);
+            witherSkullEntity.setCharged(true);
+
+            int headIndex = RANDOM.nextInt(3);
+            double g = getHeadX(headIndex);
+            double h = getHeadY(headIndex);
+            double i = getHeadZ(headIndex);
+            witherSkullEntity.setPos(g, h, i);
+            owner.world.spawnEntity(witherSkullEntity);
+            return true;
+        }
+
+        private double getHeadX(int headIndex) {
+            if (headIndex <= 0) {
+                return owner.getX();
+            } else {
+                float f = (owner.bodyYaw + (float)(180 * (headIndex - 1))) * 0.017453292F;
+                float g = MathHelper.cos(f);
+                return owner.getX() + (double)g * 1.3D;
+            }
+        }
+
+        private double getHeadY(int headIndex) {
+            return headIndex <= 0 ? owner.getY() + 3.0D : owner.getY() + 2.2D;
+        }
+
+        private double getHeadZ(int headIndex) {
+            if (headIndex <= 0) {
+                return owner.getZ();
+            } else {
+                float f = (owner.bodyYaw + (float)(180 * (headIndex - 1))) * 0.017453292F;
+                float g = MathHelper.sin(f);
+                return owner.getZ() + (double)g * 1.3D;
+            }
+        }
+    }
+
+    public static class BlackWitherSkullAbility extends DirectAbilityBase<WitherEntity, LivingEntity> {
+        private static final Random RANDOM = new Random();
+
+        public BlackWitherSkullAbility(WitherEntity owner, int cooldown) {
+            super(owner, cooldown, 20, LivingEntity.class);
+        }
+
+        public BlackWitherSkullAbility(WitherEntity owner) {
+            this(owner,40);
+        }
+
+        @Override
+        protected boolean run(LivingEntity target) {
+            if (!owner.isSilent()) {
+                owner.world.syncWorldEvent(null, 1024, owner.getBlockPos(), 0);
+            }
+
+            int headIndex = RANDOM.nextInt(3);
+            double g = getHeadX(headIndex);
+            double h = getHeadY(headIndex);
+            double i = getHeadZ(headIndex);
+            double j = target.getX() - g;
+            double k = target.getY() + (double)target.getStandingEyeHeight() * 0.5D - h;
+            double l = target.getZ() - i;
+            WitherSkullEntity witherSkullEntity = new WitherSkullEntity(owner.world, owner, j, k, l);
+            witherSkullEntity.setOwner(owner);
+
+            witherSkullEntity.setPos(g, h, i);
+            owner.world.spawnEntity(witherSkullEntity);
+            return true;
+        }
+
+        private double getHeadX(int headIndex) {
+            if (headIndex <= 0) {
+                return owner.getX();
+            } else {
+                float f = (owner.bodyYaw + (float)(180 * (headIndex - 1))) * 0.017453292F;
+                float g = MathHelper.cos(f);
+                return owner.getX() + (double)g * 1.3D;
+            }
+        }
+
+        private double getHeadY(int headIndex) {
+            return headIndex <= 0 ? owner.getY() + 3.0D : owner.getY() + 2.2D;
+        }
+
+        private double getHeadZ(int headIndex) {
+            if (headIndex <= 0) {
+                return owner.getZ();
+            } else {
+                float f = (owner.bodyYaw + (float)(180 * (headIndex - 1))) * 0.017453292F;
+                float g = MathHelper.sin(f);
+                return owner.getZ() + (double)g * 1.3D;
+            }
+        }
+    }
+}

--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/common/entity/ability/WitherSkullAbility.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/common/entity/ability/WitherSkullAbility.java
@@ -16,13 +16,13 @@ import net.minecraft.util.math.Vec3d;
 import java.util.Random;
 
 public class WitherSkullAbility extends AbilityBase<WitherEntity> {
-    private static final Random RANDOM = new Random();
+    protected static final Random RANDOM = new Random();
 
     public WitherSkullAbility(WitherEntity owner, int cooldownTime) {
         super(owner, cooldownTime);
     }
 
-    private static double getHeadX(WitherEntity owner, int headIndex) {
+    protected double getHeadX(int headIndex) {
         if (headIndex <= 0) {
             return owner.getX();
         } else {
@@ -32,11 +32,11 @@ public class WitherSkullAbility extends AbilityBase<WitherEntity> {
         }
     }
 
-    private static double getHeadY(WitherEntity owner, int headIndex) {
+    protected double getHeadY(int headIndex) {
         return headIndex <= 0 ? owner.getY() + 3.0D : owner.getY() + 2.2D;
     }
 
-    private static double getHeadZ(WitherEntity owner, int headIndex) {
+    protected double getHeadZ(int headIndex) {
         if (headIndex <= 0) {
             return owner.getZ();
         } else {
@@ -46,22 +46,22 @@ public class WitherSkullAbility extends AbilityBase<WitherEntity> {
         }
     }
 
-    private static WitherSkullEntity summonSkullWithTarget(WitherEntity owner, double j, double k, double l) {
+    protected WitherSkullEntity summonSkullWithTarget(double dirX, double dirY, double dirZ) {
         int headIndex = RANDOM.nextInt(3);
-        double x = getHeadX(owner, headIndex);
-        double y = getHeadY(owner, headIndex);
-        double z = getHeadZ(owner, headIndex);
-        return summonSkullWithTarget(owner, x, y, z, j, k, l);
+        double x = getHeadX(headIndex);
+        double y = getHeadY(headIndex);
+        double z = getHeadZ(headIndex);
+        return summonSkullWithTarget(x, y, z, dirX, dirY, dirZ);
     }
 
-    private static WitherSkullEntity summonSkullWithTarget(WitherEntity owner, double x, double y, double z, double j, double k, double l) {
+    protected WitherSkullEntity summonSkullWithTarget(double x, double y, double z, double dirX, double dirY, double dirZ) {
         if (!owner.isSilent()) {
             owner.world.syncWorldEvent(null, 1024, owner.getBlockPos(), 0);
         }
         WitherSkullEntity witherSkullEntity = new WitherSkullEntity(
-            owner.world,
-            owner,
-            j, k, l
+            this.owner.world,
+            this.owner,
+            dirX, dirY, dirZ
         );
         witherSkullEntity.setOwner(owner);
 
@@ -88,7 +88,7 @@ public class WitherSkullAbility extends AbilityBase<WitherEntity> {
         @Override
         public boolean trigger() {
             Vec3d rot = this.owner.getRotationVec(1.0f).multiply(10);
-            summonSkullWithTarget(owner, rot.x + this.owner.getRandom().nextGaussian(), rot.y, rot.z + this.owner.getRandom().nextGaussian())
+            this.summonSkullWithTarget(rot.x + this.owner.getRandom().nextGaussian(), rot.y, rot.z + this.owner.getRandom().nextGaussian())
                 .setCharged(true);
             return true;
         }
@@ -124,13 +124,13 @@ public class WitherSkullAbility extends AbilityBase<WitherEntity> {
         @Override
         public boolean trigger(LivingEntity target) {
             int headIndex = RANDOM.nextInt(3);
-            double g = getHeadX(owner, headIndex);
-            double h = getHeadY(owner, headIndex);
-            double i = getHeadZ(owner, headIndex);
-            double j = target.getX() - g;
-            double k = target.getY() + (double)target.getStandingEyeHeight() * 0.5D - h;
-            double l = target.getZ() - i;
-            summonSkullWithTarget(owner, g, h, i, j, k, l);
+            double g = getHeadX(headIndex);
+            double h = getHeadY(headIndex);
+            double i = getHeadZ(headIndex);
+            double dirX = target.getX() - g;
+            double dirY = target.getY() + (double)target.getStandingEyeHeight() * 0.5D - h;
+            double dirZ = target.getZ() - i;
+            this.summonSkullWithTarget(g, h, i, dirX, dirY, dirZ);
             return true;
         }
     }

--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/mixin/common/entity/mob/WitherEntityMixin.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/mixin/common/entity/mob/WitherEntityMixin.java
@@ -1,3 +1,37 @@
+/*
+ * Requiem
+ * Copyright (C) 2017-2021 Ladysnake
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses>.
+ *
+ * Linking this mod statically or dynamically with other
+ * modules is making a combined work based on this mod.
+ * Thus, the terms and conditions of the GNU General Public License cover the whole combination.
+ *
+ * In addition, as a special exception, the copyright holders of
+ * this mod give you permission to combine this mod
+ * with free software programs or libraries that are released under the GNU LGPL
+ * and with code included in the standard release of Minecraft under All Rights Reserved (or
+ * modified versions of such code, with unchanged license).
+ * You may copy and distribute such a system following the terms of the GNU GPL for this mod
+ * and the licenses of the other code concerned.
+ *
+ * Note that people who make modified versions of this mod are not obligated to grant
+ * this special exception for their modified versions; it is their choice whether to do so.
+ * The GNU General Public License gives permission to release a modified version without this exception;
+ * this exception also makes it possible to release a modified version which carries forward this exception.
+ */
 package ladysnake.pandemonium.mixin.common.entity.mob;
 
 import ladysnake.requiem.api.v1.possession.Possessable;

--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/mixin/common/entity/mob/WitherEntityMixin.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/mixin/common/entity/mob/WitherEntityMixin.java
@@ -1,0 +1,18 @@
+package ladysnake.pandemonium.mixin.common.entity.mob;
+
+import ladysnake.requiem.api.v1.possession.Possessable;
+import net.minecraft.entity.boss.WitherEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WitherEntity.class)
+public class WitherEntityMixin {
+    @Inject(method = "method_6877", at = @At("HEAD"), cancellable = true)
+    private void cancelAttack(int headIndex, double d, double e, double f, boolean bl, CallbackInfo ci) {
+        if (((Possessable) this).isBeingPossessed()) {
+            ci.cancel();
+        }
+    }
+}

--- a/expansions/pandemonium/src/main/resources/mixins.pandemonium.common.json
+++ b/expansions/pandemonium/src/main/resources/mixins.pandemonium.common.json
@@ -11,6 +11,7 @@
     "entity.mob.LivingEntityAccessor",
     "entity.mob.PandaEntityMixin",
     "entity.mob.WitchEntityMixin",
+    "entity.mob.WitherEntityMixin",
     "entity.mob.WololoGoalMixin",
     "entity.player.PlayerEntityAccessor"
   ],


### PR DESCRIPTION
This PR adds indirect and direct abilities to the wither (although it can only be possessed with datapacks). The blue wither skull is launched on indirect, the black on direct (range 20, like the mob, cooldown 40 on both).

Autocloser edit: Fixes #224 