### PR TITLE
Update Haema compat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,8 @@ eldritch_mobs_version=8d45e7a209
 libgui_version=3.3.5+1.16.5
 ## v1.2.8
 allure_version=3109572
-## v1.3.1
-haema_version=3094430
+## v1.6.0
+haema_version=3246172
 ## v2.2.13
 bumblezone_version=3136995
 ## v0.2.0

--- a/src/main/java/ladysnake/requiem/compat/mixin/haema/VampireBloodInjectorItemMixin.java
+++ b/src/main/java/ladysnake/requiem/compat/mixin/haema/VampireBloodInjectorItemMixin.java
@@ -34,7 +34,7 @@
  */
 package ladysnake.requiem.compat.mixin.haema;
 
-import com.williambl.haema.item.VampireBloodInjectorItem;
+import com.williambl.haema.blood.injector.VampireBloodInjectorItem;
 import ladysnake.requiem.api.v1.remnant.RemnantComponent;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;


### PR DESCRIPTION
Haema 1.6 (maybe 1.5?) updated the package structure, breaking Requiem's mixin. This PR fixes that.