### PR TITLE
Added keepItemsOnDissociate gamerule

### DIFF
--- a/expansions/pandemonium/src/main/java/ladysnake/pandemonium/PandemoniumRequiemPlugin.java
+++ b/expansions/pandemonium/src/main/java/ladysnake/pandemonium/PandemoniumRequiemPlugin.java
@@ -89,6 +89,7 @@ public class PandemoniumRequiemPlugin implements RequiemPlugin {
                 success = true;
             } else if (possessionComponent.getPossessedEntity() != null && PlayerBodyTracker.get(player).getAnchor() != null) {
                 // TODO make a gamerule to keep the inventory when leaving a mob
+                //Implemented that in the main mod, still working on balancing, defaults to off - HexBliss
                 possessionComponent.stopPossessing();
                 success = true;
             } else {

--- a/src/main/java/ladysnake/requiem/common/gamerule/RequiemGamerules.java
+++ b/src/main/java/ladysnake/requiem/common/gamerule/RequiemGamerules.java
@@ -57,7 +57,8 @@ public class RequiemGamerules {
         register("disableCure", GameRuleFactory.createBooleanRule(false), GameRules.Category.PLAYER);
     public static final GameRules.Key<EnumRule<StartingRemnantType>> STARTING_SOUL_MODE =
         register("startingRemnantType", GameRuleFactory.createEnumRule(StartingRemnantType.CHOOSE), GameRules.Category.PLAYER);
-
+    public static final GameRules.Key<GameRules.BooleanRule> KEEP_ITEMS =
+        register("keepItemsOnDissociate", GameRuleFactory.createBooleanRule(false), GameRules.Category.PLAYER);
     public static void init() {
         // static init
     }

--- a/src/main/java/ladysnake/requiem/mixin/common/possession/possessed/PossessableLivingEntityMixin.java
+++ b/src/main/java/ladysnake/requiem/mixin/common/possession/possessed/PossessableLivingEntityMixin.java
@@ -335,7 +335,7 @@ abstract class PossessableLivingEntityMixin extends Entity implements Possessabl
 
             if (possessor.isAlive() && secondLife != null) {    // player didn't get killed by attrition
                 possessor.world.spawnEntity(secondLife);
-                possessionComponent.stopPossessing(world.getGameRules().getBoolean(RequiemGamerules.KEEP_ITEMS)
+                possessionComponent.stopPossessing(world.getGameRules().getBoolean(RequiemGamerules.KEEP_ITEMS));
                 if (possessionComponent.startPossessing(secondLife)) {
                     RequiemCriteria.PLAYER_RESURRECTED_AS_ENTITY.handle(possessor, secondLife);
                 } else {

--- a/src/main/java/ladysnake/requiem/mixin/common/possession/possessed/PossessableLivingEntityMixin.java
+++ b/src/main/java/ladysnake/requiem/mixin/common/possession/possessed/PossessableLivingEntityMixin.java
@@ -335,7 +335,7 @@ abstract class PossessableLivingEntityMixin extends Entity implements Possessabl
 
             if (possessor.isAlive() && secondLife != null) {    // player didn't get killed by attrition
                 possessor.world.spawnEntity(secondLife);
-                possessionComponent.stopPossessing(false);
+                possessionComponent.stopPossessing(world.getGameRules().getBoolean(RequiemGamerules.KEEP_ITEMS)
                 if (possessionComponent.startPossessing(secondLife)) {
                     RequiemCriteria.PLAYER_RESURRECTED_AS_ENTITY.handle(possessor, secondLife);
                 } else {


### PR DESCRIPTION
Added a gamerule to allow players to control whether they drop their items when dissociating. In it's current state it is fairly op but that's why it's off by default.