### PR TITLE
Fixed the issue with biomemakover decayed.

### DIFF
--- a/src/main/resources/data/requiem/tags/entity_types/humanoid_zombies.json
+++ b/src/main/resources/data/requiem/tags/entity_types/humanoid_zombies.json
@@ -11,6 +11,7 @@
     {"id": "mobz:tank_entity", "required": false},
     {"id": "mobz:armored_entity", "required": false},
     {"id": "mobz:smallzombie_entity", "required": false},
-    {"id": "mobz:fast_entity", "required": false}
+    {"id": "mobz:fast_entity", "required": false},
+    {"id": "biomemakeover:decayed", "required": false}
   ]
 }


### PR DESCRIPTION
As per [Exend#501 on Discord](https://discord.com/channels/292744693803122688/477596847129624591/844348620212011029): "the Decayed cant hold items even though it holds things while its not being possessed"

This PR fixes that by adding decayed into humanoid_zombies.json