### PR TITLE
Fix mortician loot drops

### DIFF
--- a/src/main/java/ladysnake/requiem/common/loot/RiftMorticianLootCondition.java
+++ b/src/main/java/ladysnake/requiem/common/loot/RiftMorticianLootCondition.java
@@ -70,7 +70,7 @@ public class RiftMorticianLootCondition implements LootCondition {
 
     @Override
     public boolean test(LootContext lootContext) {
-        return lootContext.get(this.entity.getParameter()) instanceof MorticianEntity mortician && mortician.isObeliskProjection();
+        return (lootContext.get(this.entity.getParameter()) instanceof MorticianEntity mortician && mortician.isObeliskProjection()) == rift;
     }
 
     public static class Serializer implements JsonSerializer<RiftMorticianLootCondition> {


### PR DESCRIPTION
Added XAND gate to give the rift boolean use. Previously, the rift boolean was read but unused.